### PR TITLE
Qt testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,12 @@ RUN DEBIAN_FRONTEND=noninteractive \
 		expect \
 		snmp
 
+RUN DEBIAN_FRONTEND=noninteractive \
+	apt-get -y --no-install-recommends install \
+		xvfb \
+		xvnc4viewer \
+		ffmpeg
+
 CMD mount -t tmpfs none /var/nfs_test && \
 	service rpcbind restart && \
 	/etc/init.d/nfs-kernel-server restart && \

--- a/ntp.conf
+++ b/ntp.conf
@@ -2,9 +2,19 @@
 
 driftfile /var/lib/ntp/ntp.drift
 
-
 # Enable this if you want statistics to be logged.
 #statsdir /var/log/ntpstats/
+
+# Use servers from the NTP Pool Project. Approved by Ubuntu Technical Board
+# on 2011-02-08 (LP: #104525). See http://www.pool.ntp.org/join.html for
+# more information.
+pool 0.ubuntu.pool.ntp.org iburst
+pool 1.ubuntu.pool.ntp.org iburst
+pool 2.ubuntu.pool.ntp.org iburst
+pool 3.ubuntu.pool.ntp.org iburst
+
+# Use Ubuntu's ntp server as a fallback.
+pool ntp.ubuntu.com
 
 statistics loopstats peerstats clockstats
 filegen loopstats file loopstats type day enable
@@ -12,6 +22,3 @@ filegen peerstats file peerstats type day enable
 filegen clockstats file clockstats type day enable
 
 restrict 10.0.2.0 mask 255.255.255.0 nomodify notrap
-
-server 127.127.1.1
-fudge 127.127.1.1 stratum 1


### PR DESCRIPTION
There are two contributions:

* Add packages required for Qt testing;
* ntp.conf is fixed due to new version of ntpd, I guess. I didn't dig in depths, but the old version won't work, while the ntpdate works well with a new one.